### PR TITLE
Update CMake configuration for debug build and enhance synchronizatio…

### DIFF
--- a/ownOpenRTI/src/newTry/CMakeLists.txt
+++ b/ownOpenRTI/src/newTry/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
+set(CMAKE_BUILD_TYPE Debug)
+
 # Add executable for main.cpp
 add_executable(newTry src/main.cpp src/fedAmbassador.cpp src/Federate.cpp)
 add_executable(tryPub src/mainPub.cpp src/fedAmbassador.cpp src/pubFederate.cpp)

--- a/ownOpenRTI/src/newTry/include/fedAmbassador.h
+++ b/ownOpenRTI/src/newTry/include/fedAmbassador.h
@@ -46,7 +46,7 @@ public:
                                 const rti1516e::ObjectClassHandle& theObjectClass,
                                 const std::wstring& theObjectName);
 
-    void synchronizationPointAnnounced(std::wstring const& label, const rti1516e::VariableLengthData& tag);
+    
 
     void setVehiclePosition(double position);
     double getVehiclePosition() const;
@@ -62,6 +62,7 @@ public:
     bool isSyncPointAnnounced() const;
 
     void synchronizationPointAchieved(std::wstring const& label, bool successfully);
+    void synchronizationPointAnnounced(std::wstring const& label, const rti1516e::VariableLengthData& tag);
 
 private:
     std::wstring syncPointLabel = L"VehicleReadyForSync";

--- a/ownOpenRTI/src/newTry/src/fedAmbassador.cpp
+++ b/ownOpenRTI/src/newTry/src/fedAmbassador.cpp
@@ -126,7 +126,7 @@ bool FederateAmbassador::isSyncPointAnnounced() const {
 void FederateAmbassador::synchronizationPointAnnounced(std::wstring const& label, const rti1516e::VariableLengthData& tag) { // Add the scope resolution operator
     if (label == L"VehicleReady") {
         syncPointAnnounced = true;
-        syncPointLabel = label;
+        syncPointLabel = label; // For debugging purposes
         std::wcout << "[DEBUG] synchronizationPointAnnounced() called! Label: " << label << std::endl;
     }
 }

--- a/ownOpenRTI/src/newTry/src/pubFederate.cpp
+++ b/ownOpenRTI/src/newTry/src/pubFederate.cpp
@@ -143,7 +143,9 @@ void Federate::publishOnly() {
         std::wcout << "Published vehicleClassHandle: " << vehicleClassHandle << std::endl;
 
         // 🔹 ANNOUNCE SYNCHRONIZATION POINT
-        _rtiAmbassador->registerFederationSynchronizationPoint(L"VehicleReady", rti1516e::VariableLengthData());
+        std::this_thread::sleep_for(std::chrono::seconds(6));
+        rti1516e::FederateHandleSet emptyVector;    // Should send to *all* federates in the federation
+        _rtiAmbassador->registerFederationSynchronizationPoint(L"VehicleReady", rti1516e::VariableLengthData(), emptyVector);
         std::wcout << "Synchronization point 'VehicleReady' announced." << std::endl;
 
         // 🔹 WAIT FOR ALL FEDERATES TO ACHIEVE SYNC
@@ -157,8 +159,9 @@ void Federate::publishOnly() {
 }
 
 void Federate::waitForSyncPoint() {
+    _rtiAmbassador->enableCallbacks();
     while (!fedAmb->isSyncPointAchieved()) {
-        bool processed = _rtiAmbassador->evokeCallback(1.0);
+        bool processed = _rtiAmbassador->evokeMultipleCallbacks(0.1, 1.0);
         std::cout << "[DEBUG] evokeCallback returned: " << (processed ? "true" : "false") << std::endl;
     }
     std::cout << "[DEBUG] Sync achieved! Exiting wait loop." << std::endl;


### PR DESCRIPTION
This pull request includes several changes to the `ownOpenRTI` project, focusing on synchronization, debugging, and federation initialization improvements. The most important changes include setting the build type to Debug, reordering and enhancing synchronization methods, adding debugging information, and modifying the federation joining process to handle retries.

Enhancements to synchronization and debugging:

* [`ownOpenRTI/src/newTry/CMakeLists.txt`](diffhunk://#diff-8cfa0a2a33ef25e9b3eda0a8f3d3561f934a5ee940a1982c9e8d3c4ea03a51b2R3-R4): Set the CMake build type to Debug to facilitate debugging.
* [`ownOpenRTI/src/newTry/include/fedAmbassador.h`](diffhunk://#diff-440b803a00f462bccb7c5ddfc1e5f980259be504de3e0d6fbdd05cf34443a9d3L49-R49): Reordered the `synchronizationPointAnnounced` method for better organization. [[1]](diffhunk://#diff-440b803a00f462bccb7c5ddfc1e5f980259be504de3e0d6fbdd05cf34443a9d3L49-R49) [[2]](diffhunk://#diff-440b803a00f462bccb7c5ddfc1e5f980259be504de3e0d6fbdd05cf34443a9d3R65)
* [`ownOpenRTI/src/newTry/src/fedAmbassador.cpp`](diffhunk://#diff-a925b528354a33a9d663b085ab79e8df2c87fabe9121f70cdb6d12a21f598c70L129-R129): Added a debug message to the `synchronizationPointAnnounced` method.

Improvements to federation synchronization and initialization:

* [`ownOpenRTI/src/newTry/src/pubFederate.cpp`](diffhunk://#diff-6b85121b8a9bdde6865b51d17217f0096c1c5bccdcc93aa4f93006694acdee17L146-R148): Added a delay and modified the synchronization point registration to include an empty vector, ensuring it is sent to all federates. Enabled callbacks and used `evokeMultipleCallbacks` for better synchronization handling. [[1]](diffhunk://#diff-6b85121b8a9bdde6865b51d17217f0096c1c5bccdcc93aa4f93006694acdee17L146-R148) [[2]](diffhunk://#diff-6b85121b8a9bdde6865b51d17217f0096c1c5bccdcc93aa4f93006694acdee17R162-R164)
* [`ownOpenRTI/src/newTry/src/subFederate.cpp`](diffhunk://#diff-0531b4a9c7e5bacb16233c6d475f91b15346647d8e984fb770b3dd81b283d4d5R49-R53): Commented out the initialization of the federation by `subFederate` and added retry logic for joining the federation. Enabled callbacks and used `evokeMultipleCallbacks` to wait for synchronization points. [[1]](diffhunk://#diff-0531b4a9c7e5bacb16233c6d475f91b15346647d8e984fb770b3dd81b283d4d5R49-R53) [[2]](diffhunk://#diff-0531b4a9c7e5bacb16233c6d475f91b15346647d8e984fb770b3dd81b283d4d5R111-R133)…n point handling