### PR TITLE
Refactor MyFederate and MyPublisher to support object class attribute…

### DIFF
--- a/src/myProgram/MyPublisher.cpp
+++ b/src/myProgram/MyPublisher.cpp
@@ -45,30 +45,35 @@ void startPublisher(int instance) {
         rtiAmbassador->joinFederationExecution(federateName, federationName);
         std::wcout << L"MyPublisher joined: " << federateName << std::endl;
 
-        // Get handles and publish interactions
-        auto interactionClassHandle = rtiAmbassador->getInteractionClassHandle(L"HLAinteractionRoot.InteractionClass1");
-        auto parameterHandle1 = rtiAmbassador->getParameterHandle(interactionClassHandle, L"Parameter1");
-        rtiAmbassador->publishInteractionClass(interactionClassHandle);
-        std::wcout << L"Published InteractionClass1" << std::endl;
+        // Get handles and register object instance
+        auto objectClassHandle = rtiAmbassador->getObjectClassHandle(L"HLAobjectRoot.ObjectClass1");
+        auto attributeHandle = rtiAmbassador->getAttributeHandle(objectClassHandle, L"Attribute1");
+        rti1516e::AttributeHandleSet attributes;
+        attributes.insert(attributeHandle);
+        rtiAmbassador->publishObjectClassAttributes(objectClassHandle, attributes);
+        std::wcout << L"Published ObjectClass1 with Attribute1" << std::endl;
+
+        auto objectInstanceHandle = rtiAmbassador->registerObjectInstance(objectClassHandle);
+        std::wcout << L"Registered ObjectInstance: " << objectInstanceHandle << std::endl;
 
         // Random number generator
         std::random_device rd;
         std::mt19937 gen(rd());
         std::uniform_int_distribution<> dis(1, 100);
 
-        // Main loop to process callbacks and send interactions
+        // Main loop to update attribute
         while (true) {
             // Process callbacks
             rtiAmbassador->evokeMultipleCallbacks(0.1, 1.0);
             std::wcout << L"Processed callbacks" << std::endl;
 
             int32_t randomValue = dis(gen);
-            // Send interaction 
-            rti1516e::HLAinteger32BE parameterValue1(randomValue);
-            rti1516e::ParameterHandleValueMap parameters;
-            parameters[parameterHandle1] = parameterValue1.encode();
-            rtiAmbassador->sendInteraction(interactionClassHandle, parameters, rti1516e::VariableLengthData());
-            std::wcout << L"Sent InteractionClass1 with Parameter1: " << randomValue << std::endl;
+            // Update attribute
+            rti1516e::HLAinteger32BE attributeValue(randomValue);
+            rti1516e::AttributeHandleValueMap attributeValues;
+            attributeValues[attributeHandle] = attributeValue.encode();
+            rtiAmbassador->updateAttributeValues(objectInstanceHandle, attributeValues, rti1516e::VariableLengthData());
+            std::wcout << L"Updated Attribute1 with value: " << randomValue << std::endl;
 
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }

--- a/src/myProgram/foms/test_fdd.xml
+++ b/src/myProgram/foms/test_fdd.xml
@@ -29,16 +29,16 @@
       <name>HLAobjectRoot</name>
       <objectClass>
         <name>ObjectClass1</name>
+        <sharing>PublishSubscribe</sharing>
         <attribute>
           <name>Attribute1</name>
           <dataType>HLAinteger32BE</dataType>
           <updateType>Static</updateType>
           <updateCondition>NA</updateCondition>
-          <ownership>DivestAcquire</ownership>
+          <ownership>NoTransfer</ownership>
           <sharing>PublishSubscribe</sharing>
-          <dimensions/>
           <transportation>HLAreliable</transportation>
-          <order>TimeStamp</order>
+          <order>Recieve</order>
           <semantics>Test attribute</semantics>
         </attribute>
       </objectClass>


### PR DESCRIPTION
This pull request includes significant changes to the `MyFederate` and `MyPublisher` classes to shift from interaction-based communication to object-based communication. The most important changes include the removal of interaction handling methods, the addition of object instance handling methods, and updates to the XML configuration file to reflect these changes.

### Changes to `MyFederate` and `MyPublisher` classes:

* [`src/myProgram/MyFederate.cpp`](diffhunk://#diff-a5daa55f2d0894015b12d857160f2240e83288607a9ccec5742982c6e695c9c4L22-R48): Removed `receiveInteraction` method and added `discoverObjectInstance` and `reflectAttributeValues` methods to handle object instances and their attributes. Updated class members to store object class and attribute handles.
* [`src/myProgram/MyFederate.cpp`](diffhunk://#diff-a5daa55f2d0894015b12d857160f2240e83288607a9ccec5742982c6e695c9c4L72-R85): Updated `startSubscriber` method to subscribe to object class attributes instead of interactions.
* [`src/myProgram/MyPublisher.cpp`](diffhunk://#diff-01468bb8b288252e213c0acac099889e6f3975ea2a397a213854443481338c24L48-R76): Updated `startPublisher` method to register object instances and update their attributes instead of sending interactions.

### Changes to XML configuration:

* [`src/myProgram/foms/test_fdd.xml`](diffhunk://#diff-66947056d78d1350db6b0fa6083c7fc1fc6fbb661bbc9caa7319b648609b81daR32-R41): Modified the `ObjectClass1` configuration to set `sharing` to `PublishSubscribe`, change `ownership` to `NoTransfer`, and update `order` to `Receive`.…s and update mechanisms