### PR TITLE
Update FOM file paths in CMakeLists.txt and source files for consistency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,6 @@ link_directories(${Source_Directory}/libs)
 # Link OpenRTI libraries (correct library names without 'lib' prefix or '.so' suffix)
 
 # Copy the FOM.xml file to the build directory
-file(COPY ${CMAKE_SOURCE_DIR}/foms DESTINATION ${CMAKE_BINARY_DIR})
+file(COPY ${CMAKE_SOURCE_DIR}/src/myProgram/foms DESTINATION ${CMAKE_BINARY_DIR})
 
 add_subdirectory(src/myProgram)

--- a/src/myProgram/MyFederate.cpp
+++ b/src/myProgram/MyFederate.cpp
@@ -160,7 +160,7 @@ void startSubscriber(int instance) {
         // Create or join federation
         std::wstring federationName = L"robotFederation";
         std::vector<std::wstring> fomModules = {
-            L"/usr/OjOpenRTI/OpenRTI/src/myProgram/foms/robot.xml"
+            L"foms/robot.xml"
         };
         std::wstring mimModule = L"foms/MIM.xml";
         try {

--- a/src/myProgram/MyPublisher.cpp
+++ b/src/myProgram/MyPublisher.cpp
@@ -33,7 +33,7 @@ void startPublisher(int instance) {
         // Create or join federation
         std::wstring federationName = L"robotFederation";
         std::vector<std::wstring> fomModules = {
-            L"/usr/OjOpenRTI/OpenRTI/src/myProgram/foms/robot.xml"
+            L"foms/robot.xml"
         };
         std::wstring mimModule = L"foms/MIM.xml";
         try {

--- a/src/myProgram/MyShip.cpp
+++ b/src/myProgram/MyShip.cpp
@@ -33,7 +33,7 @@ void startShipPublisher(int instance) {
         // Create or join federation
         std::wstring federationName = L"robotFederation";
         std::vector<std::wstring> fomModules = {
-            L"/usr/OjOpenRTI/OpenRTI/src/myProgram/foms/robot.xml"
+            L"foms/robot.xml"
         };
         std::wstring mimModule = L"foms/MIM.xml";
         try {


### PR DESCRIPTION
This pull request includes changes to streamline the file paths used in the project and update the build configuration. The most important changes include modifying the paths for FOM modules and updating the `CMakeLists.txt` file to correctly copy the FOM files.

Updates to file paths:

* [`src/myProgram/MyFederate.cpp`](diffhunk://#diff-a5daa55f2d0894015b12d857160f2240e83288607a9ccec5742982c6e695c9c4L163-R163): Changed the path for `robot.xml` in the `startSubscriber` method to a relative path.
* [`src/myProgram/MyPublisher.cpp`](diffhunk://#diff-01468bb8b288252e213c0acac099889e6f3975ea2a397a213854443481338c24L36-R36): Changed the path for `robot.xml` in the `startPublisher` method to a relative path.
* [`src/myProgram/MyShip.cpp`](diffhunk://#diff-715a48ac601e58399e228c7aac720e15696c8fb68ead6ff8b2cf7f78f0fdce23L36-R36): Changed the path for `robot.xml` in the `startShipPublisher` method to a relative path.

Build configuration:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL25-R25): Updated the `file(COPY ...)` command to use the correct source directory for copying FOM files.