### PR TITLE
Add RPATH settings to CMakeLists.txt for proper library linking

### DIFF
--- a/src/myProgram/CMakeLists.txt
+++ b/src/myProgram/CMakeLists.txt
@@ -6,6 +6,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
 
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
 add_executable(MyFederate MyFederate.cpp)
 add_executable(MyPublisher MyPublisher.cpp)
 add_executable(MyShip MyShip.cpp)


### PR DESCRIPTION
This pull request includes changes to the `CMakeLists.txt` file to improve the build configuration for the project. The most important changes focus on setting the runtime path for installed binaries.

Build configuration improvements:

* [`src/myProgram/CMakeLists.txt`](diffhunk://#diff-49f7a5e84dc0c2cf7919339c53a336e93862f98e0a9d6753bab86d9f6b218342R9-R11): Added `set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)` to ensure the runtime path is set for installed binaries.
* [`src/myProgram/CMakeLists.txt`](diffhunk://#diff-49f7a5e84dc0c2cf7919339c53a336e93862f98e0a9d6753bab86d9f6b218342R9-R11): Added `set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")` to specify the directory for the runtime path.