### PR TITLE
Add syncPoint function

### DIFF
--- a/src/myProgram/MyFederate.cpp
+++ b/src/myProgram/MyFederate.cpp
@@ -178,6 +178,24 @@ public:
         }
     }
 
+    void announceSynchronizationPoint(
+        std::wstring const& label,
+        rti1516e::VariableLengthData const& theUserSuppliedTag)
+    {
+        if (label == L"InitialSync") {
+            std::wcout << L"Publisher Federate received synchronization announcement: InitialSync." << std::endl;
+            syncLabel = label;
+        }
+    
+        // Not in use
+        if (label == L"ShutdownSync") {
+            std::wcout << L"Publisher Federate received synchronization announcement: ShutdownSync." << std::endl;
+            syncLabel = label; 
+        }
+    }
+
+    std::wstring syncLabel = L"";
+
     //MyRobot definitions
     rti1516e::ObjectClassHandle objectClassHandle;
     rti1516e::AttributeHandle attributeHandleName;
@@ -352,6 +370,13 @@ void startSubscriber(int instance) {
         }
         rtiAmbassador->joinFederationExecution(federateName, federationName);
         std::wcout << L"MyFederate joined: " << federateName << std::endl;
+
+        // Achieve sync point
+        std::wcout << L"MyFederate waiting for synchronization announcement..." << std::endl;
+        while(federateAmbassador->syncLabel != L"InitialSync") {
+            rtiAmbassador->evokeMultipleCallbacks(0.1, 1.0);
+        }
+        std::wcout << L"MyFederate received sync point." << std::endl;
 
         // Get handles and subscribe to object class attributes
         federateAmbassador->objectClassHandle = rtiAmbassador->getObjectClassHandle(L"HLAobjectRoot.robot");

--- a/src/myProgram/MyPublisher.cpp
+++ b/src/myProgram/MyPublisher.cpp
@@ -21,11 +21,28 @@ std::wstring getPosition();
 double getAltitude();
 double getFuelLevel(double speed);
 double getSpeed();
+bool userInteraction();
 
 class MyPublisherFederateAmbassador : public rti1516e::NullFederateAmbassador {
 public:
     MyPublisherFederateAmbassador() : subscribedToPosition(true) {}
 
+    void announceSynchronizationPoint (
+        std::wstring  const & label,
+        rti1516e::VariableLengthData const & theUserSuppliedTag)
+   {
+       if (label == L"InitialSync") {
+           std::wcout << L"Master Federate synchronized at InitialSync." << std::endl;
+           syncLabel = label;
+       }
+   
+       // Not in use
+       if (label == L"ShutdownSync") {
+           std::wcout << L"Master Federate synchronized at ShutdownSync." << std::endl;
+           syncLabel = label;
+       }
+   }
+    std::wstring syncLabel = L"";
     bool subscribedToPosition;
 };
 
@@ -81,6 +98,17 @@ double getSpeed(double cSpeed, double minSpeed, double maxSpeed) {
     return newSpeed;
 }
 
+bool userInteraction() {
+    std::string input = "temp";
+    while(true){
+        std::getline(std::cin, input);
+        if (input == "") {
+            break;
+        }
+    }
+    return true;
+}
+
 void startPublisher(int instance) {
     std::wstring federateName = L"Publisher" + std::to_wstring(instance);
 
@@ -105,6 +133,30 @@ void startPublisher(int instance) {
         }
         rtiAmbassador->joinFederationExecution(federateName, federationName);
         std::wcout << L"MyPublisher joined: " << federateName << std::endl;
+        
+        std::wcout << "Press [Enter] to register synchronization point..." << std::endl;
+        userInteraction();
+
+        try{
+            rtiAmbassador->registerFederationSynchronizationPoint(L"InitialSync", rti1516e::VariableLengthData());
+            std::wcout << L"MyPublisher waiting for synchronization..." << std::endl;
+
+            while(federateAmbassador->syncLabel != L"InitialSync") {
+                rtiAmbassador->evokeMultipleCallbacks(0.1, 1.0);
+            }
+
+            std::wcout << L"MyPublisher has announced synchronization point: InitialSync" << std::endl;
+        } catch (const rti1516e::RTIinternalError& e) {
+            std::wcout << L"Error while registering synchronization point: " << e.what() << std::endl;
+        }
+
+        try {
+            rtiAmbassador->synchronizationPointAchieved(L"InitialSync", true);
+            std::cout << "Synchronization point 'InitialSync' achieved!" << std::endl;
+        } catch (const rti1516e::RTIinternalError& e) {
+            std::wcout << L"Error while achieving synchronization point: " << e.what() << std::endl;
+        }
+       
 
         // Get handles and register object instance
         auto objectClassHandle = rtiAmbassador->getObjectClassHandle(L"HLAobjectRoot.robot");

--- a/src/myProgram/MyShip.cpp
+++ b/src/myProgram/MyShip.cpp
@@ -23,6 +23,24 @@ double getAngle();  //not implemented
 class MyShipFederateAmbassador : public rti1516e::NullFederateAmbassador {
 public:
     MyShipFederateAmbassador() {}
+
+    void announceSynchronizationPoint(
+        std::wstring const& label,
+        rti1516e::VariableLengthData const& theUserSuppliedTag)
+    {
+        if (label == L"InitialSync") {
+            std::wcout << L"Publisher Federate received synchronization announcement: InitialSync." << std::endl;
+            syncLabel = label;
+        }
+    
+        // Not in use
+        if (label == L"ShutdownSync") {
+            std::wcout << L"Publisher Federate received synchronization announcement: ShutdownSync." << std::endl;
+            syncLabel = label; 
+        }
+    }
+
+    std::wstring syncLabel = L"";
 };
 
 std::wstring generateShipPosition(double publisherLat, double publisherLon) {
@@ -65,6 +83,13 @@ void startShipPublisher(int instance) {
         }
         rtiAmbassador->joinFederationExecution(federateName, federationName);
         std::wcout << L"MyShip joined: " << federateName << std::endl;
+
+        // Achieve sync point
+        std::wcout << L"ShipPublisher waiting for synchronization announcement..." << std::endl;
+        while(federateAmbassador->syncLabel != L"InitialSync") {
+            rtiAmbassador->evokeMultipleCallbacks(0.1, 1.0);
+        }
+        std::wcout << L"ShipPublisher received sync point." << std::endl;
 
         // Get handles and register object instance
         auto objectClassHandle = rtiAmbassador->getObjectClassHandle(L"HLAobjectRoot.ship");

--- a/src/myProgram/foms/robot.xml
+++ b/src/myProgram/foms/robot.xml
@@ -227,6 +227,14 @@
             </interactionClass>
         </interactionClass>
     </interactions>
+      <!-- Example synchronizationPoint. Sync is optional -->
+    <synchronizations>
+        <synchronizationPoint>
+            <label>InitialSync</label>
+            <capability>Achieve</capability>
+            <semantics>Achieved when all federates are ready to proceed</semantics>
+        </synchronizationPoint>
+    </synchronizations>
     <switches>
         <autoProvide isEnabled="true"/>
         <conveyRegionDesignatorSets isEnabled="false"/>


### PR DESCRIPTION
This pull request introduces synchronization points to ensure that different federates in the system are synchronized before proceeding. The changes include adding synchronization point handling in multiple federate classes and updating the XML configuration to define the synchronization points.

### Synchronization point handling:

* [`src/myProgram/MyFederate.cpp`](diffhunk://#diff-a5daa55f2d0894015b12d857160f2240e83288607a9ccec5742982c6e695c9c4R181-R198): Added `announceSynchronizationPoint` method and `syncLabel` attribute to handle synchronization announcements. Updated `startSubscriber` method to wait for the `InitialSync` synchronization point. [[1]](diffhunk://#diff-a5daa55f2d0894015b12d857160f2240e83288607a9ccec5742982c6e695c9c4R181-R198) [[2]](diffhunk://#diff-a5daa55f2d0894015b12d857160f2240e83288607a9ccec5742982c6e695c9c4R374-R380)
* [`src/myProgram/MyPublisher.cpp`](diffhunk://#diff-01468bb8b288252e213c0acac099889e6f3975ea2a397a213854443481338c24R24-R45): Added `announceSynchronizationPoint` method and `syncLabel` attribute to handle synchronization announcements. Introduced `userInteraction` method to wait for user input before registering the synchronization point. Updated `startPublisher` method to register and achieve the `InitialSync` synchronization point. [[1]](diffhunk://#diff-01468bb8b288252e213c0acac099889e6f3975ea2a397a213854443481338c24R24-R45) [[2]](diffhunk://#diff-01468bb8b288252e213c0acac099889e6f3975ea2a397a213854443481338c24R101-R111) [[3]](diffhunk://#diff-01468bb8b288252e213c0acac099889e6f3975ea2a397a213854443481338c24R137-R160)
* [`src/myProgram/MyShip.cpp`](diffhunk://#diff-715a48ac601e58399e228c7aac720e15696c8fb68ead6ff8b2cf7f78f0fdce23R26-R43): Added `announceSynchronizationPoint` method and `syncLabel` attribute to handle synchronization announcements. Updated `startShipPublisher` method to wait for the `InitialSync` synchronization point. [[1]](diffhunk://#diff-715a48ac601e58399e228c7aac720e15696c8fb68ead6ff8b2cf7f78f0fdce23R26-R43) [[2]](diffhunk://#diff-715a48ac601e58399e228c7aac720e15696c8fb68ead6ff8b2cf7f78f0fdce23R87-R93)

### XML configuration update:

* [`src/myProgram/foms/robot.xml`](diffhunk://#diff-9597698a91f304af67c5f8c7fc982fd021a981ec7f9cb72ebbaa3495520ce97eR230-R237): Added a new synchronization point `InitialSync` with the capability to achieve synchronization when all federates are ready.