### PR TITLE
Missile target system version 1.0.0.X.1

### DIFF
--- a/src/CombinedShip/ShipFederateAmbassador.cpp
+++ b/src/CombinedShip/ShipFederateAmbassador.cpp
@@ -76,6 +76,30 @@ void MyShipFederateAmbassador::receiveInteraction(
     rti1516e::OrderType receivedOrder,
     rti1516e::SupplementalReceiveInfo receiveInfo) {
     std::wcout << L"[DEBUG] Recieve interaction called with time" << std::endl;
+
+    if (interactionClassHandle == interactionClassTargetHit) {
+
+        auto it = parameterValues.find(parameterHandleTargetHitID);
+        if (it != parameterValues.end()) {
+            rti1516e::VariableLengthData attributeValue = it->second;
+            rti1516e::HLAunicodeString value;
+            value.decode(attributeValue);
+            std::wstring targetID = value.get();
+            std::wcout << L"Target ID: " << targetID << std::endl;
+        
+            for (const auto& [objectInstanceHandle, index] : friendlyShipIndexMap) {
+                Ship& friendlyShip = friendlyShips[index];
+                if (friendlyShip.shipName == targetID) {
+                    std::wcout << L"Ship destroyed" << std::endl;
+                    friendlyShips[index] = std::move(friendlyShips.back());
+                    friendlyShipIndexMap[friendlyShips[index].objectInstanceHandle] = index;
+                    friendlyShips.pop_back();
+                    friendlyShipIndexMap.erase(objectInstanceHandle);
+                    return;
+                }
+            }
+        }
+    }
 }
 
 void MyShipFederateAmbassador::receiveInteraction(
@@ -429,3 +453,41 @@ rti1516e::ParameterHandle MyShipFederateAmbassador::getParamMissileSpeed() const
 void MyShipFederateAmbassador::setParamMissileSpeed(const rti1516e::ParameterHandle& handle) {
     parameterHandleMissileSpeed = handle;
 }
+
+// Getter and setter functions for interaction class targetHit
+rti1516e::InteractionClassHandle MyShipFederateAmbassador::getInteractionClassTargetHit() const {
+    return interactionClassTargetHit;
+}
+void MyShipFederateAmbassador::setInteractionClassTargetHit(const rti1516e::InteractionClassHandle& handle) {
+    interactionClassTargetHit = handle;
+}
+
+rti1516e::ParameterHandle MyShipFederateAmbassador::getParamTargetHitID() const {
+    return parameterHandleTargetHitID;
+}
+void MyShipFederateAmbassador::setParamTargetHitID(const rti1516e::ParameterHandle& handle) {
+    parameterHandleTargetHitID = handle;
+}
+
+rti1516e::ParameterHandle MyShipFederateAmbassador::getParamTargetHitTeam() const {
+    return parameterHandleTargetHitTeam;
+}
+void MyShipFederateAmbassador::setParamTargetHitTeam(const rti1516e::ParameterHandle& handle) {
+    parameterHandleTargetHitTeam = handle;
+}
+
+rti1516e::ParameterHandle MyShipFederateAmbassador::getParamTargetHitPosition() const {
+    return parameterHandleTargetHitPosition;
+}
+void MyShipFederateAmbassador::setParamTargetHitPosition(const rti1516e::ParameterHandle& handle) {
+    parameterHandleTargetHitPosition = handle;
+}
+
+rti1516e::ParameterHandle MyShipFederateAmbassador::getParamTargetHitDestroyed() const {
+    return parameterHandleTargetHitDestroyed;
+}
+void MyShipFederateAmbassador::setParamTargetHitDestroyed(const rti1516e::ParameterHandle& handle) {
+    parameterHandleTargetHitDestroyed = handle;
+}
+
+

--- a/src/CombinedShip/ShipFederateAmbassador.h
+++ b/src/CombinedShip/ShipFederateAmbassador.h
@@ -82,6 +82,13 @@ class MyShipFederateAmbassador : public rti1516e::NullFederateAmbassador {
     rti1516e::ParameterHandle parameterHandleNumberOfMissilesFired;
     rti1516e::ParameterHandle parameterHandleMissileSpeed;
 
+    //Parameters and handle for interaction class TargetHit
+    rti1516e::InteractionClassHandle interactionClassTargetHit;
+    rti1516e::ParameterHandle parameterHandleTargetHitID;
+    rti1516e::ParameterHandle parameterHandleTargetHitTeam;
+    rti1516e::ParameterHandle parameterHandleTargetHitPosition;
+    rti1516e::ParameterHandle parameterHandleTargetHitDestroyed;
+
     void readJsonFile();
 
 
@@ -194,6 +201,22 @@ public:
 
     rti1516e::ParameterHandle getParamMissileSpeed() const;
     void setParamMissileSpeed(const rti1516e::ParameterHandle& handle);
+
+    // Getters and setters for targetHit
+    rti1516e::InteractionClassHandle getInteractionClassTargetHit() const;
+    void setInteractionClassTargetHit(const rti1516e::InteractionClassHandle& handle);
+
+    rti1516e::ParameterHandle getParamTargetHitID() const;
+    void setParamTargetHitID(const rti1516e::ParameterHandle& handle);
+
+    rti1516e::ParameterHandle getParamTargetHitTeam() const;
+    void setParamTargetHitTeam(const rti1516e::ParameterHandle& handle);
+
+    rti1516e::ParameterHandle getParamTargetHitPosition() const;
+    void setParamTargetHitPosition(const rti1516e::ParameterHandle& handle);
+
+    rti1516e::ParameterHandle getParamTargetHitDestroyed() const;
+    void setParamTargetHitDestroyed(const rti1516e::ParameterHandle& handle);
 
     //Standard values get/set
     std::wstring getEnemyShipFederateName() const;

--- a/src/MissileManagerFederate/MissileFederate.h
+++ b/src/MissileManagerFederate/MissileFederate.h
@@ -37,6 +37,8 @@ private:
     void runSimulationLoop();
     void resignFederation();
 
+    void sendTargetHitInteraction(Missile& missile, const rti1516e::LogicalTime& logicalTime);
+
     std::unique_ptr<rti1516e::RTIambassador> rtiAmbassador;
     std::unique_ptr<MissileFederateAmbassador> federateAmbassador;
 
@@ -53,4 +55,4 @@ private:
     std::wstring targetFederateName;
 };
 
-#endif
+#endif // MISSILEFEDERATE_H

--- a/src/MissileManagerFederate/MissileFederateAmbassador.cpp
+++ b/src/MissileManagerFederate/MissileFederateAmbassador.cpp
@@ -233,54 +233,6 @@ void MissileFederateAmbassador::receiveInteraction(
             return;
         }
     }
-    else if (interactionClassHandle == interactionClassMissileFlight) {
-        for(const auto& param : parameterValues) {
-            if (param.first == parameterHandleMissileFlightID) {
-                rti1516e::HLAunicodeString tempValue;
-                tempValue.decode(param.second);
-                std::wstring missileID = tempValue.get();
-                std::wcout << L"[INFO] Missile ID: " << missileID << std::endl;
-            } else if (param.first == parameterHandleMissileFlightTeam) {
-                rti1516e::HLAunicodeString tempValue;
-                tempValue.decode(param.second);
-                std::wstring missileTeam = tempValue.get();
-                std::wcout << L"[INFO] Missile Team: " << missileTeam << std::endl;
-            } else if (param.first == parameterHandleMissileStartPosition) {
-                std::pair<double, double> missilePosition = decodePositionRec(param.second);
-                std::wcout << L"[INFO] Missile Position: " << missilePosition.first << ", "
-                << missilePosition.second << std::endl;
-            } else if (param.first == parameterHandleMissileFlightAltitude) {
-                rti1516e::HLAfloat64BE tempValue;
-                tempValue.decode(param.second);
-                double missileAltitude = tempValue.get();
-                std::wcout << L"[INFO] Missile Altitude: " << missileAltitude << std::endl;
-            } else if (param.first == parameterHandleMissileSpeed) {
-                rti1516e::HLAfloat64BE tempValue;
-                tempValue.decode(param.second);
-                double missileSpeed = tempValue.get();
-                std::wcout << L"[INFO] Missile Speed: " << missileSpeed << std::endl;
-            } else if (param.first == parameterHandleMissileFlightLockOnTargetID) {
-                rti1516e::HLAunicodeString tempValue;
-                tempValue.decode(param.second);
-                std::wstring lockOnTargetID = tempValue.get();
-                std::wcout << L"[INFO] Lock on Target ID: " << lockOnTargetID << std::endl;
-            } else if (param.first == parameterHandleMissileFlightHitTarget) {
-                rti1516e::HLAboolean tempValue;
-                tempValue.decode(param.second);
-                bool hitTarget = tempValue.get();
-                std::wcout << L"[INFO] Hit Target: " << hitTarget << std::endl;
-            } else if (param.first == parameterHandleMissileFlightDestroyed) {
-                rti1516e::HLAboolean tempValue;
-                tempValue.decode(param.second);
-                bool destroyed = tempValue.get();
-                std::wcout << L"[INFO] Missile Destroyed: " << destroyed << std::endl;
-            } else {
-                std::wcerr << L"[WARNING] Unknown parameter handle: " << param.first << std::endl;
-            }
-            /* TODO: Something with these interactions. Send some interaction when close enough to the ship. */
-        }
-
-    }
 }
 
 void MissileFederateAmbassador::addNewMissile(rti1516e::ObjectInstanceHandle objectInstanceHandle)
@@ -318,7 +270,7 @@ void MissileFederateAmbassador::createNewMissileObject(int numberOfNewMissiles)
             missiles.back().structMissilePosition = missilePosition;
             missiles.back().structInitialTargetPosition = missileTargetPosition;
             missiles.back().structMissileAltitude = 0.0;
-            missiles.back().structMissileSpeed = 4000; // m/s
+            missiles.back().structMissileSpeed = 4000; // m/s is this correct?
             missiles.back().structMissileStartTime = std::chrono::high_resolution_clock::now(); // Unsure if this needs to be an Attribute, try without for now.
             missiles.back().structInitialBearing = calculateInitialBearingDouble(
                 missilePosition.first, 
@@ -563,70 +515,6 @@ rti1516e::ParameterHandle MissileFederateAmbassador::getParamMissileSpeed() cons
 }
 void MissileFederateAmbassador::setParamMissileSpeed(const rti1516e::ParameterHandle& handle) {
     parameterHandleMissileSpeed = handle;
-}
-
-// Getter and setter functions for interaction class MissileFlight
-rti1516e::InteractionClassHandle MissileFederateAmbassador::getInteractionClassMissileFlight() const {
-    return interactionClassMissileFlight;
-}
-void MissileFederateAmbassador::setInteractionClassMissileFlight(const rti1516e::InteractionClassHandle& handle) {
-    interactionClassMissileFlight = handle;
-}
-
-rti1516e::ParameterHandle MissileFederateAmbassador::getParamMissileFlightID() const {
-    return parameterHandleMissileFlightID;
-}
-void MissileFederateAmbassador::setParamMissileFlightID(const rti1516e::ParameterHandle& handle) {
-    parameterHandleMissileFlightID = handle;
-}
-
-rti1516e::ParameterHandle MissileFederateAmbassador::getParamMissileFlightTeam() const {
-    return parameterHandleMissileFlightTeam;
-}
-void MissileFederateAmbassador::setParamMissileFlightTeam(const rti1516e::ParameterHandle& handle) {
-    parameterHandleMissileFlightTeam = handle;
-}
-
-rti1516e::ParameterHandle MissileFederateAmbassador::getParamMissileFlightPosition() const {
-    return parameterHandleMissileFlightPosition;
-}
-void MissileFederateAmbassador::setParamMissileFlightPosition(const rti1516e::ParameterHandle& handle) {
-    parameterHandleMissileFlightPosition = handle;
-}
-
-rti1516e::ParameterHandle MissileFederateAmbassador::getParamMissileFlightAltitude() const {
-    return parameterHandleMissileFlightAltitude;
-}
-void MissileFederateAmbassador::setParamMissileFlightAltitude(const rti1516e::ParameterHandle& handle) {
-    parameterHandleMissileFlightAltitude = handle;
-}
-
-rti1516e::ParameterHandle MissileFederateAmbassador::getParamMissileFlightSpeed() const {
-    return parameterHandleMissileFlightSpeed;
-}
-void MissileFederateAmbassador::setParamMissileFlightSpeed(const rti1516e::ParameterHandle& handle) {
-    parameterHandleMissileFlightSpeed = handle;
-}
-
-rti1516e::ParameterHandle MissileFederateAmbassador::getParamMissileFlightLockOnTargetID() const {
-    return parameterHandleMissileFlightLockOnTargetID;
-}
-void MissileFederateAmbassador::setParamMissileFlightLockOnTargetID(const rti1516e::ParameterHandle& handle) {
-    parameterHandleMissileFlightLockOnTargetID = handle;
-}
-
-rti1516e::ParameterHandle MissileFederateAmbassador::getParamMissileFlightHitTarget() const {
-    return parameterHandleMissileFlightHitTarget;
-}
-void MissileFederateAmbassador::setParamMissileFlightHitTarget(const rti1516e::ParameterHandle& handle) {
-    parameterHandleMissileFlightHitTarget = handle;
-}
-
-rti1516e::ParameterHandle MissileFederateAmbassador::getParamMissileFlightDestroyed() const {
-    return parameterHandleMissileFlightDestroyed;
-}
-void MissileFederateAmbassador::setParamMissileFlightDestroyed(const rti1516e::ParameterHandle& handle) {
-    parameterHandleMissileFlightDestroyed = handle;
 }
 
 // Getter and setter for targetHit Interaction

--- a/src/MissileManagerFederate/MissileFederateAmbassador.h
+++ b/src/MissileManagerFederate/MissileFederateAmbassador.h
@@ -96,16 +96,6 @@ private:
     rti1516e::ParameterHandle parameterHandleNumberOfMissilesFired;
     rti1516e::ParameterHandle parameterHandleMissileSpeed;
 
-    rti1516e::InteractionClassHandle interactionClassMissileFlight;
-    rti1516e::ParameterHandle parameterHandleMissileFlightID;
-    rti1516e::ParameterHandle parameterHandleMissileFlightTeam;
-    rti1516e::ParameterHandle parameterHandleMissileFlightPosition;
-    rti1516e::ParameterHandle parameterHandleMissileFlightAltitude;
-    rti1516e::ParameterHandle parameterHandleMissileFlightSpeed;
-    rti1516e::ParameterHandle parameterHandleMissileFlightLockOnTargetID;
-    rti1516e::ParameterHandle parameterHandleMissileFlightHitTarget;
-    rti1516e::ParameterHandle parameterHandleMissileFlightDestroyed;
-
     //Parameters and handle for interaction class TargetHit
     rti1516e::InteractionClassHandle interactionClassTargetHit;
     rti1516e::ParameterHandle parameterHandleTargetHitID;


### PR DESCRIPTION
This pull request includes several changes to improve the simulation logic and clean up the codebase. The most important changes include modifying the simulation loop conditions, updating the missile firing logic, and removing or commenting out unnecessary code.

### Missile Firing Logic:
* Modified `ShipFederate::runSimulationLoop` to handle missile firing based on the distance to the target and the target's health.
* Updated `sendInteraction` method in `ShipFederate` to include the enemy ship's position when sending interaction data. [[1]](diffhunk://#diff-f51c2b93080b6176297de85dd2b67c72df7c6016c3525dafca557fc0096ee6ddL364-R382) [[2]](diffhunk://#diff-de4462543830eec4a120f613db851fc38950dee42f5e00ea38e0edef3a965385L43-R43)

### Code Cleanup:
* Commented out or removed unnecessary debug prints and unused variables in various files to clean up the codebase. [[1]](diffhunk://#diff-6755e238d3b5245cbddbb2886b5f05fd5555de8f402b9a6f2a62a789815f5e8aL18-R20) [[2]](diffhunk://#diff-3a2e4328f0950ce5e73a0b6b92ef7692e137e4cb8c69817c5a6730f662cf71b1L331-R332) [[3]](diffhunk://#diff-ce5117d7ca88316307b93e4ae60df0082210d61686a8fbe97cc00242f83fe3e2L51-R57) [[4]](diffhunk://#diff-ce5117d7ca88316307b93e4ae60df0082210d61686a8fbe97cc00242f83fe3e2L69-R75)
* Removed the `RedShip` struct and related attributes from `Ship.h` as they were not being used.

### Data Structures:
* Added a `rangeToTarget` multimap in `ShipFederateAmbassador` to keep track of targets within range, improving the missile targeting logic.

### Additional Improvements:
* Simplified the logic in `MissileFederateAmbassador::reflectAttributeValues` and `receiveInteraction` by removing redundant checks and improving target assignment messages. [[1]](diffhunk://#diff-44ad8b1cb2ac8e500ae8b76c01b819869a2f76a51b8c26ca2207f9640f1a69a7L77-R84) [[2]](diffhunk://#diff-44ad8b1cb2ac8e500ae8b76c01b819869a2f76a51b8c26ca2207f9640f1a69a7L229-L235)