### PR TITLE
Swap longitude and latitude in position extraction for missile and sh…

### DIFF
--- a/src/VisualRepresentation/ReceiveData.py
+++ b/src/VisualRepresentation/ReceiveData.py
@@ -78,7 +78,8 @@ def deserialize_missile(data):
         missile_team = data[100:200].decode('utf-16-le', errors='ignore').strip('\x00')
 
         # Extract position, speed, and altitude as doubles
-        position = struct.unpack("<dd", data[200:216])  # Two doubles (16 bytes)
+        raw_position = struct.unpack("<dd", data[200:216])  # Two doubles (16 bytes)
+        position = (raw_position[1], raw_position[0])  # Swap longitude and latitude
         speed = struct.unpack("<d", data[216:224])[0]  # One double (8 bytes)
         altitude = struct.unpack("<d", data[224:232])[0]  # One double (8 bytes)
 
@@ -95,7 +96,8 @@ def deserialize_ship(data):
         ship_team = data[100:200].decode('utf-16-le', errors='ignore').strip('\x00')
 
         # Extract position, speed, size, and HP as doubles
-        position = struct.unpack("<dd", data[200:216])  # Two doubles (16 bytes)
+        raw_position = struct.unpack("<dd", data[200:216])  # Two doubles (16 bytes)
+        position = (raw_position[1], raw_position[0])  # Swap longitude and latitude
         speed = struct.unpack("<d", data[216:224])[0]  # One double (8 bytes)
         size = struct.unpack("<d", data[224:232])[0]  # One double (8 bytes)
         HP = struct.unpack("<d", data[232:240])[0]  # One double (8 bytes)


### PR DESCRIPTION
This pull request includes changes to the `src/VisualRepresentation/ReceiveData.py` file to correct the order of latitude and longitude in the `deserialize_missile` and `deserialize_ship` functions. The most important changes include swapping the longitude and latitude values after unpacking the position data.

Changes to position data handling:

* [`src/VisualRepresentation/ReceiveData.py`](diffhunk://#diff-7a9a13da29da0a11fa9ec47103060d83f2fc3ba2562ea7f1646af97fe70be9dfL81-R82): In the `deserialize_missile` function, unpacked position data is now assigned to `raw_position` and then swapped to correct the order of longitude and latitude.
* [`src/VisualRepresentation/ReceiveData.py`](diffhunk://#diff-7a9a13da29da0a11fa9ec47103060d83f2fc3ba2562ea7f1646af97fe70be9dfL98-R100): In the `deserialize_ship` function, unpacked position data is now assigned to `raw_position` and then swapped to correct the order of longitude and latitude.…ip deserialization