### PR TITLE
236 add readme missilecreator

### DIFF
--- a/src/MissileCreator/README.md
+++ b/src/MissileCreator/README.md
@@ -64,4 +64,4 @@ Unlike other federates, MissileCreator does **not** simulate missile behavior it
 ---
 
 **Summary:**  
-MissileCreator is the bridge between ship fire requests and missile simulation. It ensures that each missile is launched as a separate federate, enabling scalable and concurrent missile simulation within
+MissileCreator is the bridge between ship fire requests and missile simulation. It ensures that each missile is launched as a separate federate, enabling scalable and concurrent missile simulation within the federation.

--- a/src/MissileCreator/README.md
+++ b/src/MissileCreator/README.md
@@ -1,0 +1,67 @@
+# MissileCreator Federate
+
+**MissileCreator** is a C++ federate built using the IEEE HLA (High-Level Architecture) standard. Its primary role is to act as an asynchronous missile launcher: it listens for fire requests from ship federates and dynamically spawns new missile instances during the simulation.
+
+Unlike other federates, MissileCreator does **not** simulate missile behavior itself. Its sole purpose is to detect fire interactions and launch new processes that run MissileFederate instances via `./MissileHandler`.
+
+---
+
+## Purpose
+
+- Listens for missile creation interactions from ShipFederate.
+- Launches a new MissileFederate process (via `./MissileHandler`) for each missile requested.
+- Ensures each missile runs in its own independent process.
+- Converts and forwards RTI data necessary to initialize missiles.
+- Synchronizes with the rest of the federation for coordinated startup and time management.
+
+---
+
+## File Overview
+
+### MissileCreator.cpp / MissileCreator.h
+
+- **Core application logic:**
+  - RTI setup:
+    - `createRTIAmbassador()`
+    - `connectToRTI()`
+    - `initializeFederation()`
+    - `joinFederation()`
+  - Handle and interaction setup:
+    - `initializeHandles()`
+    - `subscribeInteractions()`
+  - **Main loop:**
+    - Waits at the synchronization point until the simulation begins.
+    - Delegates missile-launching behavior to the Ambassador.
+
+### MissileCreatorFederateAmbassador.cpp / MissileCreatorFederateAmbassador.h
+
+- Handles all RTI communication and contains the core missile-launching logic:
+  - `announceSynchronizationPoint()` — Synchronizes with the federation before simulation starts.
+  - `receiveInteraction()` — Detects fire interactions sent by ShipFederate.
+  - `StartMissile()` — Core logic to create and launch new missile processes:
+    - Forks a new process for each missile, separating it from the parent federate.
+    - Prepares arguments (converts RTI parameters to usable C++ values).
+    - Launches the missile using `execv()` to run `./MissileHandler`, which starts a new MissileFederate.
+
+---
+
+## Runtime Behavior
+
+- MissileCreator runs quietly in the background during the simulation.
+- Reacts only when a ship initiates a fire request.
+- For every fire request received:
+  - A new MissileFederate is launched in its own process, allowing multiple missiles to be simulated concurrently.
+- Waits for simulation end by monitoring the synchronization point.
+
+---
+
+## Notes
+
+- **MissileCreator does not simulate missiles** — this is entirely delegated to the MissileFederate instances it launches.
+- This federate **must be running** for missiles to be spawned when ships fire.
+- All inter-process communication and RTI setup for each missile happens inside MissileFederate after being launched by MissileCreator.
+
+---
+
+**Summary:**  
+MissileCreator is the bridge between ship fire requests and missile simulation. It ensures that each missile is launched as a separate federate, enabling scalable and concurrent missile simulation within

--- a/src/README.md
+++ b/src/README.md
@@ -140,6 +140,9 @@ Each federate or major component in this project has its own `README.md` file lo
 - **ShipFederate/**  
   Has a README explaining how ships are initialized, their attributes (like size and robot count), and how they send fire interactions to launch missiles.
 
+- **MissileCreator/**  
+  Contains a README describing how MissileCreator launches new Missile federates in response to ship fire requests.
+
 - **VisualRepresentation/CommunicationWithPython/**  
   Contains a README for the PyLink federate, which subscribes to RTI data and sends it to Python for visualization via sockets.  
   **Note:** PyLink is required for `ReceiveData.py` to function. The README explains its purpose and implementation.


### PR DESCRIPTION
This pull request adds documentation for the `MissileCreator` federate, clarifying its role in the simulation and how it interacts with other components. The main changes are the addition of a detailed `README.md` for `MissileCreator` and an update to the project-level `README.md` to reference this new documentation.

Documentation additions:

* Added a comprehensive `README.md` to `src/MissileCreator/` describing the purpose, runtime behavior, and file structure of the `MissileCreator` federate. The documentation explains how it listens for fire requests from ships and launches new missile processes, detailing the separation of responsibilities between `MissileCreator` and `MissileFederate`.

Project-level documentation update:

* Updated `src/README.md` to include a reference to the new `MissileCreator/README.md`, ensuring users are aware of the federate's documentation and its role in launching missile federates in response to ship fire requests.