### PR TITLE
Update federation name from 'robotFederation' to 'Federation' across multiple headers.

### DIFF
--- a/src/AdminFederate/AdminFederate.h
+++ b/src/AdminFederate/AdminFederate.h
@@ -50,7 +50,7 @@ private:
     rti1516e::HLAfloat64TimeFactory* logicalTimeFactory = nullptr;
 
     std::wstring federateName = L"AdminFederate";
-    std::wstring federationName = L"robotFederation";
+    std::wstring federationName = L"Federation";
     std::vector<std::wstring> fomModules = {L"foms/FOM.xml"};
     std::wstring minModule = L"foms/MIM.xml";
 

--- a/src/MissileCreator/MissileCreator.h
+++ b/src/MissileCreator/MissileCreator.h
@@ -22,7 +22,7 @@ private:
     void resignFederation();
 
     std::wstring federateName = L"MissileCreatorFederate_" + std::to_wstring(getpid());
-    std::wstring federationName = L"robotFederation";
+    std::wstring federationName = L"Federation";
     std::vector<std::wstring> fomModules = {L"foms/FOM.xml"};
     std::wstring mimModule = L"foms/MIM.xml";
 

--- a/src/MissileFederate/MissileFederate.h
+++ b/src/MissileFederate/MissileFederate.h
@@ -40,7 +40,7 @@ private:
     std::unique_ptr<MissileFederateAmbassador> myfederateAmbassador;
 
     std::wstring federateName = L"MissileManagerFederate_" + std::to_wstring(getpid());
-    std::wstring federationName = L"robotFederation";
+    std::wstring federationName = L"Federation";
     std::vector<std::wstring> fomModules = {L"foms/FOM.xml"};
     std::wstring mimModule = L"foms/MIM.xml";
 

--- a/src/ShipFederate/ShipFederate.h
+++ b/src/ShipFederate/ShipFederate.h
@@ -46,7 +46,7 @@ private:
     std::unordered_map<Ship*, int> tempLockingCount;
     
     std::wstring federateName = L"ShipFederate";
-    std::wstring federationName = L"robotFederation";
+    std::wstring federationName = L"Federation";
     std::vector<std::wstring> fomModules = {L"foms/FOM.xml"};
     std::wstring mimModule = L"foms/MIM.xml";
 };

--- a/src/VisualRepresentation/CommunicationWithPython/PyLink.h
+++ b/src/VisualRepresentation/CommunicationWithPython/PyLink.h
@@ -47,7 +47,7 @@ private:
     rti1516e::HLAfloat64TimeFactory* logicalTimeFactory = nullptr;
 
     std::wstring federateName = L"PyLink";
-    std::wstring federationName = L"robotFederation";
+    std::wstring federationName = L"Federation";
     std::vector<std::wstring> fomModules = {L"foms/FOM.xml"};
     std::wstring minModule = L"foms/MIM.xml";
 


### PR DESCRIPTION
This pull request standardizes the federation name across multiple federate classes in the codebase. Previously, each federate used the name `robotFederation`; this has been updated to `Federation` for consistency.

Federation name standardization:

* Updated the `federationName` member from `robotFederation` to `Federation` in the following classes:
  * `AdminFederate` (`src/AdminFederate/AdminFederate.h`)
  * `MissileCreatorFederate` (`src/MissileCreator/MissileCreator.h`)
  * `MissileFederate` (`src/MissileFederate/MissileFederate.h`)
  * `ShipFederate` (`src/ShipFederate/ShipFederate.h`)
  * `PyLink` (`src/VisualRepresentation/CommunicationWithPython/PyLink.h`)